### PR TITLE
[Feat] 에러 객체 수정

### DIFF
--- a/src/main/java/com/mannavoca/zenga/common/ResponseCode/ResponseCode.java
+++ b/src/main/java/com/mannavoca/zenga/common/ResponseCode/ResponseCode.java
@@ -1,0 +1,30 @@
+package com.mannavoca.zenga.common.ResponseCode;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ResponseCode {
+
+    // Common
+    OK(HttpStatus.OK, "정상적으로 처리되었습니다.", "O200"),
+
+    // party
+    PARTY_CREATED(HttpStatus.OK, "모임 생성을 성공하였습니다.", "P001"),
+    PARTY_UPDATED(HttpStatus.OK, "모임 정보 수정을 성공하였습니다.", "P002"),
+    PARTY_DELETED(HttpStatus.OK, "모임 삭제를 성공하였습니다.", "P003"),
+    PARTY_JOIN_CANCELED(HttpStatus.OK, "모임 가입을 취소하였습니다.", "P004"),
+    PARTY_CARD_CREATED(HttpStatus.OK, "모임 카드 생성에 성공하였습니다.", "P005"),
+    PARTY_CARD_DELETED(HttpStatus.OK, "모임 카드 삭제에 성공하였습니다.", "P006"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String code;
+
+    ResponseCode(HttpStatus httpStatus, String message, String code) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+        this.code = code;
+    }
+}

--- a/src/main/java/com/mannavoca/zenga/common/dto/ErrorDto.java
+++ b/src/main/java/com/mannavoca/zenga/common/dto/ErrorDto.java
@@ -1,0 +1,34 @@
+package com.mannavoca.zenga.common.dto;
+
+import com.google.firebase.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorDto {
+    private int errorCode;
+    private String message;
+    private LocalDateTime timestamp;
+    private String log;
+
+    @Builder
+    public ErrorDto(int errorCode, String message, String log) {
+        this.errorCode = errorCode;
+        this.message = message;
+        this.timestamp = LocalDateTime.now();
+        this.log = log;
+    }
+
+    public static ErrorDto of(int errorCode, String message, String log) {
+        return ErrorDto.builder()
+                .errorCode(errorCode)
+                .message(message)
+                .log(log)
+                .build();
+    }
+}

--- a/src/main/java/com/mannavoca/zenga/common/dto/ResponseDto.java
+++ b/src/main/java/com/mannavoca/zenga/common/dto/ResponseDto.java
@@ -1,5 +1,6 @@
 package com.mannavoca.zenga.common.dto;
 
+import com.mannavoca.zenga.common.ResponseCode.ResponseCode;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,31 +11,32 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ResponseDto<T> {
-    private int code;
+    private ResponseCode code;
     private String message;
     private LocalDateTime timestamp;
     private T data;
 
     @Builder
-    public ResponseDto(int code, String message, T data) {
+    public ResponseDto(ResponseCode code, String message, T data) {
         this.code = code;
         this.message = message;
         this.timestamp = LocalDateTime.now();
         this.data = data;
     }
 
-    public static <T> ResponseDto<T> of(int code, String message, T data) {
+
+    public static <T> ResponseDto<T> of(ResponseCode code, T data) {
         return ResponseDto.<T>builder()
                 .code(code)
-                .message(message)
+                .message(code.getMessage())
                 .data(data)
                 .build();
     }
 
     public static <T> ResponseDto<T> success(T data) {
         return ResponseDto.<T>builder()
-                .code(200)
-                .message("SUCCESS")
+                .code(ResponseCode.OK)
+                .message(ResponseCode.OK.getMessage())
                 .data(data)
                 .build();
     }

--- a/src/main/java/com/mannavoca/zenga/common/exception/BusinessException.java
+++ b/src/main/java/com/mannavoca/zenga/common/exception/BusinessException.java
@@ -1,27 +1,18 @@
 package com.mannavoca.zenga.common.exception;
 
+import com.mannavoca.zenga.common.dto.ErrorDto;
 import com.mannavoca.zenga.common.dto.ResponseDto;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class BusinessException extends RuntimeException{
-    private final ResponseDto responseDto;
-//    private final Error error;
-
-
-//    public BusinessException(Error error) {
-//        this.error = error;
-//    }
-
-    @Builder
-    public BusinessException(ResponseDto responseDto) {
-        this.responseDto = responseDto;
+    private final Error error;
+    public BusinessException(Error error) {
+        this.error = error;
     }
 
     public static BusinessException of(Error error) {
-        return BusinessException.builder()
-                .responseDto(ResponseDto.of(error.getErrorCode(), error.getMessage(), null))
-                .build();
+        return new BusinessException(error);
     }
 }

--- a/src/main/java/com/mannavoca/zenga/common/exception/Error.java
+++ b/src/main/java/com/mannavoca/zenga/common/exception/Error.java
@@ -1,57 +1,60 @@
 package com.mannavoca.zenga.common.exception;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public enum Error {
-    INTERNAL_SERVER_ERROR("서버 내부 에러입니다.", 500),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러입니다.", 500),
 
-    DATA_NOT_FOUND("데이터를 찾을 수 없습니다.", 800),
-    FILE_UPLOAD_ERROR("s3 upload 오류입니다.", 801),
-    FILE_EXTENTION_ERROR("파일 확장자 오류입니다.", 802),
-    FILE_DELETE_ERROR("파일 삭제 오류입니다.", 803),
+    DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "데이터를 찾을 수 없습니다.", 800),
+    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "s3 upload 오류입니다.", 801),
+    FILE_EXTENTION_ERROR(HttpStatus.BAD_REQUEST,"파일 확장자 오류입니다.", 802),
+    FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"파일 삭제 오류입니다.", 803),
 
     // OAuth
-    OAUTH_FAILED("잘못된 소셜 로그인 요청입니다. KAKAO, GOOGLE, APPLE 연동만이 가능합니다.", 890),
-    GOOGLE_OAUTH_FAILED("Google에서 토큰을 검색하지 못했습니다.", 900),
-    GOOGLE_OAUTH_FAILED2("Google에서 사용자 정보를 검색하지 못했습니다.", 901),
-    KAKAO_OAUTH_FAILED("KAKAO 토큰이 만료되었습니다.", 910),
-    KAKAO_OAUTH_FAILED2("KAKAO 토큰이 올바르지 않습니다.", 911),
-    APPLE_OIDC_FAILED("Apple OAuth Identity Token 형식이 올바르지 않습니다.", 920),
-    APPLE_OIDC_FAILED2("Apple OAuth 로그인 중 Identity Token 유효기간이 만료됐습니다.", 921),
-    APPLE_OIDC_FAILED3("Apple OAuth Identity Token 값이 올바르지 않습니다.", 922),
-    APPLE_OIDC_FAILED4("Apple JWT 값의 alg, kid 정보가 올바르지 않습니다.", 923),
-    APPLE_OIDC_FAILED5("Apple OAuth 통신 암호화 과정 중 문제가 발생했습니다.", 924),
-    APPLE_OIDC_FAILED6("Apple OAuth 로그인 중 public key 생성에 문제가 발생했습니다.", 925),
-    APPLE_OIDC_FAILED7("Apple OAuth Claims 값이 올바르지 않습니다.", 926),
-    EMAIL_DUPLICATION("이미 가입된 일반 계정입니다.", 930),
-    NCP_SMS_FAILED("SMS 전송 에러입니다. 다시 시도해주세요", 950),
+    OAUTH_FAILED(HttpStatus.BAD_REQUEST,"잘못된 소셜 로그인 요청입니다. KAKAO, GOOGLE, APPLE 연동만이 가능합니다.", 890),
+    GOOGLE_OAUTH_FAILED(HttpStatus.BAD_REQUEST,"Google에서 토큰을 검색하지 못했습니다.", 900),
+    GOOGLE_OAUTH_FAILED2(HttpStatus.BAD_REQUEST,"Google에서 사용자 정보를 검색하지 못했습니다.", 901),
+    KAKAO_OAUTH_FAILED(HttpStatus.BAD_REQUEST,"KAKAO 토큰이 만료되었습니다.", 910),
+    KAKAO_OAUTH_FAILED2(HttpStatus.BAD_REQUEST,"KAKAO 토큰이 올바르지 않습니다.", 911),
+    APPLE_OIDC_FAILED(HttpStatus.BAD_REQUEST,"Apple OAuth Identity Token 형식이 올바르지 않습니다.", 920),
+    APPLE_OIDC_FAILED2(HttpStatus.BAD_REQUEST,"Apple OAuth 로그인 중 Identity Token 유효기간이 만료됐습니다.", 921),
+    APPLE_OIDC_FAILED3(HttpStatus.BAD_REQUEST,"Apple OAuth Identity Token 값이 올바르지 않습니다.", 922),
+    APPLE_OIDC_FAILED4(HttpStatus.BAD_REQUEST,"Apple JWT 값의 alg, kid 정보가 올바르지 않습니다.", 923),
+    APPLE_OIDC_FAILED5(HttpStatus.BAD_REQUEST,"Apple OAuth 통신 암호화 과정 중 문제가 발생했습니다.", 924),
+    APPLE_OIDC_FAILED6(HttpStatus.BAD_REQUEST,"Apple OAuth 로그인 중 public key 생성에 문제가 발생했습니다.", 925),
+    APPLE_OIDC_FAILED7(HttpStatus.BAD_REQUEST,"Apple OAuth Claims 값이 올바르지 않습니다.", 926),
+    EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST,"이미 가입된 일반 계정입니다.", 930),
+    NCP_SMS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"SMS 전송 에러입니다. 다시 시도해주세요", 950),
 
 
     // 사용자
-    USER_NOT_FOUND("사용자를 찾을 수 없습니다.", 1000),
-    USER_NOT_CORRECT_SMS_NUM("잘못된 인증 번호입니다.", 1001),
-    USER_NICKNAME_DUPLICATION("중복된 닉네임입니다.", 1002),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"사용자를 찾을 수 없습니다.", 1000),
+    USER_NOT_CORRECT_SMS_NUM(HttpStatus.BAD_REQUEST,"잘못된 인증 번호입니다.", 1001),
+    USER_NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST,"중복된 닉네임입니다.", 1002),
 
 
     // Field
-    TOO_MANY_INTEREST("관심 분야를 4개 이상 설정할 수 없습니다.", 1100),
-    INVALID_FIELD_TYPE("잘못된 분야 상수 값 입니다.", 1101),
+    TOO_MANY_INTEREST(HttpStatus.BAD_REQUEST,"관심 분야를 4개 이상 설정할 수 없습니다.", 1100),
+    INVALID_FIELD_TYPE(HttpStatus.BAD_REQUEST, "잘못된 분야 상수 값 입니다.", 1101),
 
     // EventInstance
-    TOO_MANY_EVENT_FIELD("이벤트 분야를 4개 이상 설정할 수 없습니다.", 1200),
+    TOO_MANY_EVENT_FIELD(HttpStatus.BAD_REQUEST,"이벤트 분야를 4개 이상 설정할 수 없습니다.", 1200),
 
 
     // JWT
-    INVALID_TOKEN("잘못된 토큰 요청", 7000),
-    EXPIRED_TOKEN("토큰 만료되었습니다. 토큰 재발행 혹은 로그인을 다시 해주세요", 7001),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST,"잘못된 토큰 요청", 7000),
+    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST,"토큰 만료되었습니다. 토큰 재발행 혹은 로그인을 다시 해주세요", 7001),
 
     ;
 
+    private final HttpStatus httpStatus;
     private final String message;
     private final int errorCode;
 
-    Error(String message, int errorCode) {
+    Error(HttpStatus httpStatus, String message, int errorCode) {
+        this.httpStatus = httpStatus;
         this.message = message;
         this.errorCode = errorCode;
     }

--- a/src/main/java/com/mannavoca/zenga/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/mannavoca/zenga/common/exception/handler/GlobalExceptionHandler.java
@@ -1,9 +1,9 @@
 package com.mannavoca.zenga.common.exception.handler;
 
-import com.mannavoca.zenga.common.dto.ResponseDto;
+import com.mannavoca.zenga.common.dto.ErrorDto;
 import com.mannavoca.zenga.common.exception.BusinessException;
+import com.mannavoca.zenga.common.exception.Error;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,11 +14,13 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {BusinessException.class})
-    public ResponseEntity<ResponseDto> handlerCustomException(BusinessException e) {
-        log.error("Status: {}, Message: {}", e.getResponseDto().getCode(), e.getMessage());
+    public ResponseEntity<ErrorDto> handlerCustomException(BusinessException e) {
+        log.error("Status: {}, Message: {}", e.getError().getErrorCode(), e.getMessage());
+
+        String log = e.getError().getErrorCode() == Error.INTERNAL_SERVER_ERROR.getErrorCode() ? e.getMessage() : null;
 
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ResponseDto.of(e.getResponseDto().getCode(), e.getResponseDto().getMessage(), null));
+                .status(e.getError().getHttpStatus())
+                .body(ErrorDto.of(e.getError().getErrorCode(), e.getError().getMessage(), log));
     }
 }

--- a/src/main/java/com/mannavoca/zenga/common/security/exception/JwtException.java
+++ b/src/main/java/com/mannavoca/zenga/common/security/exception/JwtException.java
@@ -1,12 +1,13 @@
 package com.mannavoca.zenga.common.security.exception;
 
 
+import com.mannavoca.zenga.common.dto.ErrorDto;
 import com.mannavoca.zenga.common.dto.ResponseDto;
 import com.mannavoca.zenga.common.exception.BusinessException;
 import com.mannavoca.zenga.common.exception.Error;
 
 public class JwtException extends BusinessException {
     public JwtException(Error error) {
-        super(ResponseDto.of(error.getErrorCode(), error.getMessage(), null));
+        super(error);
     }
 }

--- a/src/main/java/com/mannavoca/zenga/common/security/exception/TokenNotFoundException.java
+++ b/src/main/java/com/mannavoca/zenga/common/security/exception/TokenNotFoundException.java
@@ -1,6 +1,8 @@
 package com.mannavoca.zenga.common.security.exception;
 import com.mannavoca.zenga.common.exception.Error;
 
+import com.mannavoca.zenga.common.exception.Error;
+
 public class TokenNotFoundException extends JwtException{
     public TokenNotFoundException(Error error) {
         super(error);

--- a/src/main/java/com/mannavoca/zenga/domain/party/presentation/PartyDeleteController.java
+++ b/src/main/java/com/mannavoca/zenga/domain/party/presentation/PartyDeleteController.java
@@ -1,5 +1,6 @@
 package com.mannavoca.zenga.domain.party.presentation;
 
+import com.mannavoca.zenga.common.ResponseCode.ResponseCode;
 import com.mannavoca.zenga.common.dto.ResponseDto;
 import com.mannavoca.zenga.domain.party.application.service.PartyDeleteUseCase;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ public class PartyDeleteController {
             )
     {
         partyDeleteUseCase.cancelParty(channelId, partyId);
-        return ResponseEntity.ok(ResponseDto.of(HttpStatus.OK.value(), "모임 삭제를 성공하였습니다.", null));
+        return ResponseEntity.ok(ResponseDto.of(ResponseCode.PARTY_DELETED, null));
     }
 
     @DeleteMapping("/apply/cancel")
@@ -35,6 +36,6 @@ public class PartyDeleteController {
             )
     {
         partyDeleteUseCase.applyCancelParty(channelId, partyId);
-        return ResponseEntity.ok(ResponseDto.of(HttpStatus.OK.value(), "모임 가입 취소을 성공하였습니다.", null));
+        return ResponseEntity.ok(ResponseDto.of(ResponseCode.PARTY_JOIN_CANCELED, null));
     }
 }

--- a/src/main/java/com/mannavoca/zenga/domain/party/presentation/PartyGetController.java
+++ b/src/main/java/com/mannavoca/zenga/domain/party/presentation/PartyGetController.java
@@ -27,7 +27,7 @@ public class PartyGetController {
             )
     {
         SliceResponse<PartyTapResponseDto> partyTapResponseDtoSliceResponseDto = partySearchUseCase.searchPartyListInChannel(channelId, partyId, pageable);
-        return ResponseEntity.ok(ResponseDto.of(HttpStatus.OK.value(), "모임 조회을 성공하였습니다.", partyTapResponseDtoSliceResponseDto));
+        return ResponseEntity.ok(ResponseDto.success(partyTapResponseDtoSliceResponseDto));
     }
 
     @GetMapping("/detail/{partyId}")
@@ -38,6 +38,6 @@ public class PartyGetController {
             )
     {
         PartyDetailInfoResponseDto partyDetailInfoResponseDto = partySearchUseCase.getPartyDetailInfo(partyId, channelId);
-        return ResponseEntity.ok(ResponseDto.of(HttpStatus.OK.value(), "모임 상세정보 조회을 성공하였습니다.", partyDetailInfoResponseDto));
+        return ResponseEntity.ok(ResponseDto.success(partyDetailInfoResponseDto));
     }
 }

--- a/src/main/java/com/mannavoca/zenga/domain/party/presentation/PartyPatchController.java
+++ b/src/main/java/com/mannavoca/zenga/domain/party/presentation/PartyPatchController.java
@@ -1,5 +1,6 @@
 package com.mannavoca.zenga.domain.party.presentation;
 
+import com.mannavoca.zenga.common.ResponseCode.ResponseCode;
 import com.mannavoca.zenga.common.dto.ResponseDto;
 import com.mannavoca.zenga.domain.party.application.dto.request.CompletePartyRequestDto;
 import com.mannavoca.zenga.domain.party.application.dto.request.EditPartyInfoRequestDto;
@@ -25,7 +26,7 @@ public class PartyPatchController {
             )
     {
         CreatePartyResponseDto createPartyResponseDto = partyUpdateUseCase.editPartyInfo(channelId, editPartyInfoRequestDto);
-        return ResponseEntity.ok(ResponseDto.of(HttpStatus.OK.value(), "모임 정보 수정을 성공하였습니다.", createPartyResponseDto));
+        return ResponseEntity.ok(ResponseDto.of(ResponseCode.PARTY_UPDATED, createPartyResponseDto));
     }
 
     @PatchMapping("/finish")
@@ -36,6 +37,6 @@ public class PartyPatchController {
             )
     {
         CompletePartyResponseDto completePartyResponseDto = partyUpdateUseCase.uploadPartyCardAndComplete(channelId, completePartyRequestDto);
-        return ResponseEntity.ok(ResponseDto.of(HttpStatus.OK.value(), "모임 카드 생성에 성공하였습니다.", completePartyResponseDto));
+        return ResponseEntity.ok(ResponseDto.of(ResponseCode.PARTY_CARD_CREATED, completePartyResponseDto));
     }
 }

--- a/src/main/java/com/mannavoca/zenga/domain/party/presentation/PartyPostController.java
+++ b/src/main/java/com/mannavoca/zenga/domain/party/presentation/PartyPostController.java
@@ -1,5 +1,6 @@
 package com.mannavoca.zenga.domain.party.presentation;
 
+import com.mannavoca.zenga.common.ResponseCode.ResponseCode;
 import com.mannavoca.zenga.common.dto.ResponseDto;
 import com.mannavoca.zenga.domain.party.application.dto.request.CreatePartyRequestDto;
 import com.mannavoca.zenga.domain.party.application.dto.response.CreatePartyResponseDto;
@@ -23,7 +24,7 @@ public class PartyPostController {
             )
     {
         CreatePartyResponseDto createPartyResponseDto = partyCreateUseCase.createNewParty(channelId, createPartyRequestDto);
-        return ResponseEntity.ok(ResponseDto.of(HttpStatus.OK.value(), "모임 생성을 성공하였습니다.", createPartyResponseDto));
+        return ResponseEntity.ok(ResponseDto.of(ResponseCode.PARTY_CREATED, createPartyResponseDto));
     }
 
     @PostMapping("/apply")
@@ -34,6 +35,6 @@ public class PartyPostController {
             )
     {
         partyCreateUseCase.applyParty(channelId, partyId);
-        return ResponseEntity.ok(ResponseDto.of(HttpStatus.OK.value(), "모임 신청을 성공하였습니다.", null));
+        return ResponseEntity.ok(ResponseDto.success( null));
     }
 }

--- a/src/main/java/com/mannavoca/zenga/domain/praise/presentation/PraiseGetController.java
+++ b/src/main/java/com/mannavoca/zenga/domain/praise/presentation/PraiseGetController.java
@@ -1,5 +1,6 @@
 package com.mannavoca.zenga.domain.praise.presentation;
 
+import com.mannavoca.zenga.common.ResponseCode.ResponseCode;
 import com.mannavoca.zenga.common.dto.PageResponse;
 import com.mannavoca.zenga.common.dto.ResponseDto;
 import com.mannavoca.zenga.domain.praise.application.dto.response.CurrentTodoPraiseResponseDto;
@@ -25,7 +26,7 @@ public class PraiseGetController {
     public ResponseEntity<ResponseDto<CurrentTodoPraiseResponseDto>> getMyCurrentToDoPraise(@RequestParam Long channelId)
     {
         CurrentTodoPraiseResponseDto currentTodoPraiseResponseDto = praiseSearchUseCase.getCurrentTodoPraiseAndMemberList(channelId);
-        return ResponseEntity.ok(ResponseDto.of(200, "칭찬 보내기 데이터 조ㅅ에 성공했습니다.", currentTodoPraiseResponseDto));
+        return ResponseEntity.ok(ResponseDto.success(currentTodoPraiseResponseDto));
     }
 
     @GetMapping("/receive")
@@ -36,7 +37,7 @@ public class PraiseGetController {
             )
     {
         PageResponse<ReceivedPraiseInfoResponseDto> pageResponse = praiseSearchUseCase.getReceivedPraiseList(channelId, page);
-        return ResponseEntity.ok(ResponseDto.of(200, "받은 칭찬 리스트 조회에 성공했습니다.", pageResponse));
+        return ResponseEntity.ok(ResponseDto.success(pageResponse));
     }
 
     @GetMapping("/send")
@@ -47,6 +48,6 @@ public class PraiseGetController {
             )
     {
         PageResponse<SendPraiseInfoResponseDto> pageResponse = praiseSearchUseCase.getSendPraiseList(channelId, page);
-        return ResponseEntity.ok(ResponseDto.of(200, "보낸 칭찬 리스트 조회에 성공했습니다.", pageResponse));
+        return ResponseEntity.ok(ResponseDto.success(pageResponse));
     }
 }

--- a/src/main/java/com/mannavoca/zenga/domain/praise/presentation/PraisePatchController.java
+++ b/src/main/java/com/mannavoca/zenga/domain/praise/presentation/PraisePatchController.java
@@ -1,5 +1,6 @@
 package com.mannavoca.zenga.domain.praise.presentation;
 
+import com.mannavoca.zenga.common.ResponseCode.ResponseCode;
 import com.mannavoca.zenga.common.dto.ResponseDto;
 import com.mannavoca.zenga.domain.praise.application.dto.request.ChooseMemberPraiseRequestDto;
 import com.mannavoca.zenga.domain.praise.application.dto.response.CurrentTodoPraiseResponseDto;
@@ -20,7 +21,7 @@ public class PraisePatchController {
     public ResponseEntity<ResponseDto<CurrentTodoPraiseResponseDto>> getMyCurrentToDoPraiseShuffle(@RequestParam Long channelId)
     {
         CurrentTodoPraiseResponseDto currentTodoPraiseResponseDto = praiseUpdateUseCase.getAgainCurrentTodoPraiseAndMemberList(channelId);
-        return ResponseEntity.ok(ResponseDto.of(200, "칭찬 보내기 셔플 데이터 조회에 성공했습니다.", currentTodoPraiseResponseDto));
+        return ResponseEntity.ok(ResponseDto.success(currentTodoPraiseResponseDto));
     }
 
     @PatchMapping("/choice")
@@ -30,6 +31,6 @@ public class PraisePatchController {
             )
     {
         praiseUpdateUseCase.choosePraise(chooseMemberPraiseRequestDto);
-        return ResponseEntity.ok(ResponseDto.of(200, "칭찬 보내기에 성공했습니다.", null));
+        return ResponseEntity.ok(ResponseDto.success(null));
     }
 }


### PR DESCRIPTION
## 변경점
 
* [에러 핸들러에서 Error Enum에 따라 다른 HttpStatus 코드를 리턴하도록 수정](https://github.com/Manna-voca/zenga-backend/compare/dev...feat/error-handler?expand=1#diff-fc882a73258ce67f657d9fc3a49e83b9109d864376e9308796c8e5f87e7aa770R16)
    * 기존에는 모든 에러를 400으로 리턴
    * 모든 예외 케이스가 400인 경우에는 예외 상황과 httpStatus 코드가 일치하지 않는 경우가 있을 수 있기 때문
      * ex) 모임을 찾을 수 없음 -> 원래 404가 적절해보이지만 실제 리턴은 400이 리턴될것
      * 서버 오류의 경우에도 500대신 400이 출력되는 것은 직관적이지 않음
      *[ Error Enum에 우리 자체 에러코드에 매핑되는 httpStatus 코드를 추가하도록 변경](https://github.com/Manna-voca/zenga-backend/compare/dev...feat/error-handler?expand=1#diff-ec95867891c818bcf6c3201caeb2b893b565bc6b2e0162d6c961b662242dda1eR7)

* [서버 에러일 경우 오류 메세지를 에러 객체에 추가](https://github.com/Manna-voca/zenga-backend/compare/dev...feat/error-handler?expand=1#diff-fc882a73258ce67f657d9fc3a49e83b9109d864376e9308796c8e5f87e7aa770R20)
    * 디버깅하기 쉽게 서버 오류일때에만 오류 메세지 출력되도록 함